### PR TITLE
bug fix: Registration before clone does not work correctly

### DIFF
--- a/tests/test_clone.py
+++ b/tests/test_clone.py
@@ -7,6 +7,11 @@ import dicon
 class A:
     pass
 
+@dicon.inject_di_container('_di_container')
+class B:
+    def __init__(self):
+        assert self._di_container.resolve[A]
+
 
 class TestClone(unittest.TestCase):
     def test_clone(self):
@@ -49,3 +54,20 @@ class TestClone(unittest.TestCase):
             y._freezed,
             True
         )
+
+    def test_do_not_bind_di_container_before_clone(self):
+        x = dicon.DIContainer()
+        x.register[B]()
+
+        y = x.clone()
+        y.register[A]()
+        assert y.resolve[B]()
+        y.freeze()
+        assert y.resolve[B]()
+
+        z = x.clone()
+        x.freeze()
+        z.register[A]()
+        assert z.resolve[B]()
+        z.freeze()
+        assert z.resolve[B]()

--- a/tests/test_clone.py
+++ b/tests/test_clone.py
@@ -10,27 +10,27 @@ class A:
 
 class TestClone(unittest.TestCase):
     def test_clone(self):
-        di_container = dicon.DIContainer()
-        di_container.register[A]()
-        di_container.register_singleton('b', 'bar')
+        x = dicon.DIContainer()
+        x.register[A]()
+        x.register_singleton('b', 'bar')
 
-        x = di_container.clone()
+        y = x.clone()
 
-        di_container.freeze()
+        x.freeze()
 
         self.assertEqual(
-            x.resolve[A],
-            di_container.resolve[A]
+            y.resolve[A],
+            x.resolve[A]
         )
         self.assertEqual(
-            x.singleton['b'],
-            di_container.singleton['b']
+            y.singleton['b'],
+            x.singleton['b']
         )
         self.assertEqual(
-            x._freezed,
+            y._freezed,
             False
         )
         self.assertEqual(
-            di_container._freezed,
+            x._freezed,
             True
         )

--- a/tests/test_clone.py
+++ b/tests/test_clone.py
@@ -23,7 +23,7 @@ class TestClone(unittest.TestCase):
 
         x.freeze()
 
-        self.assertEqual(
+        self.assertNotEqual(
             y.resolve[A],
             x.resolve[A]
         )
@@ -42,7 +42,7 @@ class TestClone(unittest.TestCase):
 
         y.freeze()
 
-        self.assertEqual(
+        self.assertNotEqual(
             y.resolve[A],
             x.resolve[A]
         )

--- a/tests/test_clone.py
+++ b/tests/test_clone.py
@@ -34,3 +34,18 @@ class TestClone(unittest.TestCase):
             x._freezed,
             True
         )
+
+        y.freeze()
+
+        self.assertEqual(
+            y.resolve[A],
+            x.resolve[A]
+        )
+        self.assertEqual(
+            y.singleton['b'],
+            x.singleton['b']
+        )
+        self.assertEqual(
+            y._freezed,
+            True
+        )

--- a/tests/test_init_method.py
+++ b/tests/test_init_method.py
@@ -62,3 +62,25 @@ class TestInitMethod(unittest.TestCase):
                 duck_params[key],
                 orig_params[key]
             )
+
+    def test_factories_differ_until_freezed(self):
+        di_container = dicon.DIContainer()
+        di_container.register[Duck]()
+
+        self.assertNotEqual(
+            di_container.resolve[Duck],
+            di_container.resolve[Duck]
+        )
+
+        x = di_container.resolve[Duck]
+        di_container.freeze()
+        y = di_container.resolve[Duck]
+        self.assertNotEqual(
+            x,
+            y
+        )
+
+        self.assertEqual(
+            di_container.resolve[Duck],
+            di_container.resolve[Duck]
+        )


### PR DESCRIPTION
example: `test_do_not_bind_di_container_before_clone`

I fixed this problem as the following:

1. Avoid binding DI container in `register`.
2. Do it in `freeze` and `resolve` before `freeze`.
